### PR TITLE
Triple shots and combat locations sharing

### DIFF
--- a/src/blueteam/ImportantLocations.java
+++ b/src/blueteam/ImportantLocations.java
@@ -1,0 +1,124 @@
+package blueteam;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import battlecode.common.GameActionException;
+import battlecode.common.MapLocation;
+import battlecode.common.RobotController;
+
+/**
+ * Provides access to the locations saved in the broadcast. Enables robots to
+ * report new important locations.
+ *
+ * @author Tomas
+ *
+ */
+public class ImportantLocations {
+	private static final int RECORD_SIZE = 3;
+	private static final int DEFAULT_LOCATIONS_NUMBER = 5;
+	private static final int DEFAULT_ROUNDS_TO_GET_OUTDATED = 15;
+
+	private final int first_locations_channel;
+	private final int locations_number;
+	private final int rounds_to_get_outdated;
+	private RobotController rc;
+	private LocationRecord[] proxy;
+	private int roundProxyUpdated = -1;
+
+	public ImportantLocations(RobotController rc, int first_location_channel, int locations_number,
+			int rounds_to_get_outdated) {
+		this.rc = rc;
+		this.first_locations_channel = first_location_channel;
+		this.locations_number = locations_number;
+		this.rounds_to_get_outdated = rounds_to_get_outdated;
+	}
+
+	public ImportantLocations(RobotController rc, int first_location_channel) {
+		this(rc, first_location_channel, DEFAULT_LOCATIONS_NUMBER, DEFAULT_ROUNDS_TO_GET_OUTDATED);
+	}
+
+	/**
+	 * Gets a list of active locations, sorted by distance from the robot.
+	 *
+	 * @return
+	 */
+	public MapLocation[] getActiveLocations() {
+		LocationRecord[] loc = getLocations();
+		int outdatedTime = rc.getRoundNum() - rounds_to_get_outdated;
+		MapLocation me = rc.getLocation();
+		return Arrays.stream(loc).filter(x -> x.lastActiveRound != 0 && x.lastActiveRound >= outdatedTime)
+				.map(x -> x.location).sorted(Comparator.comparingDouble(x -> x.distanceTo(me)))
+				.toArray(x -> new MapLocation[x]);
+	}
+
+	/**
+	 * Puts the location into the shared list of important locations. If the
+	 * capacity is full, replaces the oldest location.
+	 *
+	 * @param loc
+	 */
+	public void reportLocation(MapLocation loc) {
+		LocationRecord[] records = getLocations();
+		for (int i = 0; i < records.length; i++) {
+			if (records[i].equals(loc)) {
+				writeLocation(i, loc);
+				return;
+			}
+		}
+		// replace the least active location
+		int minIndex = 0;
+		int minRound = Integer.MAX_VALUE;
+		for (int i = 0; i < records.length; i++) {
+			if (minRound > records[i].lastActiveRound) {
+				minIndex = i;
+				minRound = records[i].lastActiveRound;
+			}
+		}
+		writeLocation(minIndex, loc);
+	}
+
+	private LocationRecord loadLocation(int id) {
+		int record_start = record_start(id);
+		float mapX = 0;
+		float mapY = 0;
+		int lastActive = 0;
+		try {
+			mapX = rc.readBroadcastFloat(record_start);
+			mapY = rc.readBroadcastFloat(record_start + 1);
+			lastActive = rc.readBroadcast(record_start + 2);
+		} catch (GameActionException e) {
+			e.printStackTrace();
+		}
+
+		return new LocationRecord(new MapLocation(mapX, mapY), lastActive);
+	}
+
+	private void writeLocation(int id, MapLocation loc) {
+		int record_start = record_start(id);
+		try {
+			rc.broadcastFloat(record_start, loc.x);
+			rc.broadcastFloat(record_start + 1, loc.y);
+			rc.broadcast(record_start + 2, rc.getRoundNum());
+		} catch (GameActionException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	private int record_start(int id) {
+		return first_locations_channel + id * RECORD_SIZE;
+	}
+
+	private LocationRecord[] getLocations() {
+		if (roundProxyUpdated != rc.getRoundNum()) {
+			proxy = new LocationRecord[locations_number];
+			for (int i = 0; i < proxy.length; i++) {
+				proxy[i] = loadLocation(i);
+			}
+		}
+		roundProxyUpdated = rc.getRoundNum();
+		return proxy;
+	}
+
+}

--- a/src/blueteam/LocationRecord.java
+++ b/src/blueteam/LocationRecord.java
@@ -1,0 +1,46 @@
+package blueteam;
+
+import battlecode.common.MapLocation;
+
+/**
+ * Proxy class for ImporatantLocations, stores data loaded from the broadcast.
+ *
+ * @author Tomas
+ *
+ */
+public class LocationRecord {
+
+	public MapLocation location;
+	public int lastActiveRound;
+	// Two locations closer than DISTANCE_EPSILON will be considered to be the
+	// same location.
+	private static final int DISTANCE_EPSILON = 5;
+
+	public LocationRecord(MapLocation location, int turnLastActive) {
+		super();
+		this.location = location;
+		this.lastActiveRound = turnLastActive;
+	}
+
+	/**
+	 * Partially auto-generated equals (uses DISTANCE_EPSILON to compare
+	 * locations)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		LocationRecord other = (LocationRecord) obj;
+		if (location == null) {
+			if (other.location != null)
+				return false;
+		} else if (location.distanceTo(other.location) > DISTANCE_EPSILON)
+			return false;
+		return true;
+	}
+
+}

--- a/src/blueteam/Robot.java
+++ b/src/blueteam/Robot.java
@@ -15,6 +15,7 @@ import battlecode.common.RobotController;
 import battlecode.common.RobotInfo;
 import battlecode.common.RobotType;
 import battlecode.common.Team;
+import battlecode.common.TreeInfo;
 
 abstract public class Robot {
 	RobotController rc;
@@ -289,6 +290,46 @@ abstract public class Robot {
 				return true;
 		}
 		return false;
+	}
+
+	/**
+	 * The nearest object that would be hit by a shot in the given direction.
+	 *
+	 * @param dir
+	 * @return Might return null
+	 */
+	BodyInfo nearestInDirection(Direction dir) {
+		RobotInfo[] nearbyRobots = rc.senseNearbyRobots();
+		BodyInfo nearest = null;
+		float distance = Float.POSITIVE_INFINITY;
+		for (RobotInfo robot : nearbyRobots) {
+			if (willIHitRobot(dir, robot)) {
+				nearest = robot;
+				distance = rc.getLocation().distanceTo(nearest.getLocation());
+				break;
+			}
+		}
+		TreeInfo[] nearbyTrees = rc.senseNearbyTrees();
+		for (TreeInfo tree : nearbyTrees) {
+			if (willIHitBody(dir, tree)) {
+				if (rc.getLocation().distanceTo(tree.getLocation()) < distance) {
+					return tree;
+				}
+			}
+		}
+		return nearest;
+	}
+
+	boolean isEnemy(BodyInfo body) {
+		if (body == null)
+			return false;
+		return (body.isTree() ? ((TreeInfo) body).getTeam() : ((RobotInfo) body).getTeam()) == enemy;
+	}
+
+	boolean isFriend(BodyInfo body) {
+		if (body == null)
+			return false;
+		return (body.isTree() ? ((TreeInfo) body).getTeam() : ((RobotInfo) body).getTeam()) == rc.getTeam();
 	}
 
 	/**

--- a/src/blueteam/TeamConstants.java
+++ b/src/blueteam/TeamConstants.java
@@ -51,5 +51,8 @@ public abstract interface TeamConstants {
 	 * get closer than this distance (reason: have enough time to dodge).
 	 */
 	public static final int MAX_SOLDIER_TO_SOLDIER_DISTANCE = 5;
+	/**
+	 * Used channels: currently 100 - 115, reserved channels 100 - 130
+	 */
 	public static final int COMBAT_LOCATIONS_FIRST_CHANNEL = 100;
 }

--- a/src/blueteam/TeamConstants.java
+++ b/src/blueteam/TeamConstants.java
@@ -12,7 +12,7 @@ public abstract interface TeamConstants {
 	// Probability that the moving direction of a soldier is chosen at random.
 	// (Otherwise the soldier tries to move towards the enemy archon's initial
 	// location.)
-	public static final double SOLDIER_RANDOM_MOVE_PROB = .75;
+	public static final double SOLDIER_RANDOM_MOVE_PROB = .55;
 	/**
 	 * robots having less than MINIMUM_HEALTH_PERCENTAGE HP are considered dead
 	 */
@@ -37,4 +37,19 @@ public abstract interface TeamConstants {
 
 	public static final int MAX_NUMBER_LUMBERJACKS = 3;
 	public static final int MAX_NUMBER_SCOUTS = 2;
+
+	/**
+	 * The soldier will not use triad shots if the number of bullets is below
+	 * this value. Solves the issue that a single soldier was able to prevent
+	 * the whole team from development by shooting (see map Conga)
+	 */
+
+	public static final int MINIMUM_BULLETS_TO_SAVE_BY_SOLDIER = 70;
+
+	/**
+	 * Maximal distance from an ENEMY soldier/tank, the robot will not try to
+	 * get closer than this distance (reason: have enough time to dodge).
+	 */
+	public static final int MAX_SOLDIER_TO_SOLDIER_DISTANCE = 5;
+	public static final int COMBAT_LOCATIONS_FIRST_CHANNEL = 100;
 }


### PR DESCRIPTION
Soldiers use triple shots.
Soldiers share enemy locations. Even other units can now report locations of the enemies through an instance of ImportantLocations. They can also instantiate ImportantLocations class with a different first channel to share their own important locations list.

Still to do:
Soldiers need proper path finding and steering.

