### PR TITLE
yo-yo like soldiers and null exception bug fix

### DIFF
--- a/src/blueteam/Soldier.java
+++ b/src/blueteam/Soldier.java
@@ -44,7 +44,7 @@ public class Soldier extends Robot {
 				if (activeLocations.length != 0 && !stuckDetected) {
 					moveDir = rc.getLocation().directionTo(activeLocations[0]);
 					rc.setIndicatorLine(rc.getLocation(), activeLocations[0], 255, 255, 0);
-					if (!rc.canMove(moveDir)) {
+					if (moveDir == null || !rc.canMove(moveDir)) {
 						stuckDetected = true;
 						rc.setIndicatorDot(rc.getLocation(), 255, 0, 0);
 						moveDir = randomFreeDirection();

--- a/src/blueteam/Soldier.java
+++ b/src/blueteam/Soldier.java
@@ -21,6 +21,7 @@ import battlecode.common.TreeInfo;
 public class Soldier extends Robot {
 
 	private Direction moveDir;
+	private boolean stuckDetected = false;
 
 	Soldier(RobotController rc) {
 		super(rc);
@@ -40,13 +41,21 @@ public class Soldier extends Robot {
 			} else {
 				MapLocation[] activeLocations = combatLocations.getActiveLocations();
 
-				if (activeLocations.length != 0) {
+				if (activeLocations.length != 0 && !stuckDetected) {
 					moveDir = rc.getLocation().directionTo(activeLocations[0]);
 					rc.setIndicatorLine(rc.getLocation(), activeLocations[0], 255, 255, 0);
+					if (!rc.canMove(moveDir)) {
+						stuckDetected = true;
+						rc.setIndicatorDot(rc.getLocation(), 255, 0, 0);
+						moveDir = randomFreeDirection();
+					}
 				}
 				if (!rc.canMove(moveDir)) {
 					// Move randomly
+
 					changeMoveDirection();
+					stuckDetected = false;
+					rc.setIndicatorDot(rc.getLocation(), 0, 255, 0);
 				}
 			}
 
@@ -89,7 +98,6 @@ public class Soldier extends Robot {
 			moveDir = randomFreeDirection();
 		} else {
 			moveDir = getDirToEnemyArchonInitLoc();
-			rc.setIndicatorDot(rc.getLocation(), 0, 255, 255);
 		}
 	}
 


### PR DESCRIPTION
 1) Soldiers get stuck less often:

After a soldier gets stuck, it moves in a random direction until it collides with something, than it changes its target back to the desired location.

Soldiers are now a bit slower, but in the end they usually reach their target. Please try it out.

2)
Null-check to prevent exceptions.